### PR TITLE
Add condition to check if measured power is in range

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,21 @@ class telldusApp extends Homey.App {
 	
 	onInit() {
 		
+		let currentPowerCondition = new Homey.FlowCardCondition('current_power');
+		currentPowerCondition
+			.register()
+			.registerRunListener(( args, state ) => {
+				var power = args.my_device.getCapabilityValue('measure_power');
+				var margin = args.W * args.errormargin / 100;
+
+				if ((power >= args.W - margin) && (power < args.W + margin))
+				{
+					return Promise.resolve( true );
+				}
+
+				return Promise.resolve( false );
+			});
+
 		this.log('${Homey.manifest.id} is running...');
 		
 	}

--- a/app.json
+++ b/app.json
@@ -40,6 +40,45 @@
         "large": "/assets/images/large.png",
         "small": "/assets/images/small.png"
     },
+    "flow": {
+    	"triggers": [],
+    	"actions": [],
+    	"conditions": [
+    		{
+    			"id": "current_power",
+    			"title": {
+    				"en": "The current power usage"
+    			},
+    			"args": [
+    				{
+                        "name": "my_device",
+                        "type": "device",
+                        "filter": "driver_id=TZWP-102"
+                    },
+    				{
+    					"name": "W",
+    					"type": "number",
+    					"min": 0,
+    					"max": 2300,
+    					"step": 10,
+    					"placeholder": {
+    						"en": "Set a value in watts"
+    					}
+    				},
+    				{
+    					"name": "errormargin",
+    					"type": "number",
+    					"min": 0,
+    					"max": 100,
+    					"step": 10,
+    					"placeholder": {
+    						"en": "Set error margin in %"
+    					}
+    				}
+    			]
+    		}
+    	]
+    },
     "drivers": [
         {
 			"id": "TZDW-100",


### PR DESCRIPTION
This would probably make even more sense in the generic `measure_power` cards (wherever they're defined) but this allows me to make a flow that uses a Telldus TZWP-102 plug to check if the TV is on before toggling power by checking the reported power consumption. (The TV doesn't support Power Off IR commands)